### PR TITLE
Update readthedocs config to v2 build schema

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,11 +1,14 @@
 version: 2
-formats: []
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
 
 sphinx:
   configuration: docs/source/conf.py
 
 python:
-  version: 3.8
   install:
     - requirements: docs/requirements.txt
     - method: pip


### PR DESCRIPTION
Migrates readthedocs.yml from the deprecated python.version key to the required build.os + build.tools.python schema (RTD enforced this since 2023-09-25, which is why builds have been silently failing since June 2023).